### PR TITLE
feat: singleton logger, root filter

### DIFF
--- a/src/__snapshots__/filter.spec.ts.snap
+++ b/src/__snapshots__/filter.spec.ts.snap
@@ -13,7 +13,7 @@ Array [
       "originalInput": "!a",
       "path": Object {
         "descendants": false,
-        "value": "a",
+        "value": ".:a",
       },
     },
   },
@@ -35,7 +35,7 @@ Array [
         "descendants": Object {
           "includeParent": true,
         },
-        "value": null,
+        "value": ".",
       },
     },
   },
@@ -57,7 +57,7 @@ Array [
         "descendants": Object {
           "includeParent": true,
         },
-        "value": null,
+        "value": ".",
       },
     },
   },
@@ -79,7 +79,7 @@ Array [
         "descendants": Object {
           "includeParent": true,
         },
-        "value": null,
+        "value": ".",
       },
     },
   },
@@ -99,7 +99,7 @@ Array [
       "originalInput": "a",
       "path": Object {
         "descendants": false,
-        "value": "a",
+        "value": ".:a",
       },
     },
   },
@@ -119,7 +119,7 @@ Array [
       "originalInput": "a",
       "path": Object {
         "descendants": false,
-        "value": "a",
+        "value": ".:a",
       },
     },
   },
@@ -134,7 +134,155 @@ Array [
       "originalInput": "b",
       "path": Object {
         "descendants": false,
-        "value": "b",
+        "value": ".:b",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse . 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".",
+      "path": Object {
+        "descendants": false,
+        "value": ".",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .:* 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".:*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .:*@1 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "eq",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".:*@1",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .::* 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".::*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": false,
+        },
+        "value": ".",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .:a 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".:a",
+      "path": Object {
+        "descendants": false,
+        "value": ".:a",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .:a:* 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": ".:a:*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".:a",
+      },
+    },
+  },
+]
+`;
+
+exports[`parse .@* 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "eq",
+        "value": "*",
+      },
+      "negate": false,
+      "originalInput": ".@*",
+      "path": Object {
+        "descendants": false,
+        "value": ".",
       },
     },
   },
@@ -154,7 +302,7 @@ Array [
       "originalInput": "a",
       "path": Object {
         "descendants": false,
-        "value": "a",
+        "value": ".:a",
       },
     },
   },
@@ -174,7 +322,7 @@ Array [
       "originalInput": "a",
       "path": Object {
         "descendants": false,
-        "value": "a",
+        "value": ".:a",
       },
     },
   },
@@ -189,7 +337,7 @@ Array [
       "originalInput": "b",
       "path": Object {
         "descendants": false,
-        "value": "b",
+        "value": ".:b",
       },
     },
   },
@@ -209,7 +357,7 @@ Array [
       "originalInput": "a:b",
       "path": Object {
         "descendants": false,
-        "value": "a:b",
+        "value": ".:a:b",
       },
     },
   },
@@ -231,7 +379,7 @@ Array [
         "descendants": Object {
           "includeParent": true,
         },
-        "value": "a:b",
+        "value": ".:a:b",
       },
     },
   },
@@ -241,8 +389,21 @@ Array [
 exports[`parse a:b:*@info 1`] = `
 Array [
   Object {
-    "_tag": "Left",
-    "left": [Error: Invalid filter pattern: "a:b:@1"],
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "eq",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": "a:b:*@1",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".:a:b",
+      },
+    },
   },
 ]
 `;
@@ -250,8 +411,21 @@ Array [
 exports[`parse app:* 1`] = `
 Array [
   Object {
-    "_tag": "Left",
-    "left": [Error: Invalid filter pattern: "app*"],
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": "app:*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".:app",
+      },
+    },
   },
 ]
 `;
@@ -259,8 +433,21 @@ Array [
 exports[`parse app:*@* 1`] = `
 Array [
   Object {
-    "_tag": "Left",
-    "left": [Error: Invalid filter pattern: "app*@*"],
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "eq",
+        "value": "*",
+      },
+      "negate": false,
+      "originalInput": "app:*@*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".:app",
+      },
+    },
   },
 ]
 `;
@@ -268,8 +455,21 @@ Array [
 exports[`parse app:*@1 1`] = `
 Array [
   Object {
-    "_tag": "Left",
-    "left": [Error: Invalid filter pattern: "app*@*"],
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "eq",
+        "value": "*",
+      },
+      "negate": false,
+      "originalInput": "app:*@*",
+      "path": Object {
+        "descendants": Object {
+          "includeParent": true,
+        },
+        "value": ".:app",
+      },
+    },
   },
 ]
 `;
@@ -289,7 +489,7 @@ Array [
         "descendants": Object {
           "includeParent": false,
         },
-        "value": "app",
+        "value": ".:app",
       },
     },
   },
@@ -309,7 +509,7 @@ Array [
       "originalInput": "app@*",
       "path": Object {
         "descendants": false,
-        "value": "app",
+        "value": ".:app",
       },
     },
   },
@@ -352,9 +552,50 @@ Array [
 ]
 `;
 
-exports[`parse syntax errors , 1`] = `Array []`;
+exports[`parse syntax errors , 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: ",. There must be at least one pattern present."],
+  },
+]
+`;
 
-exports[`parse syntax errors <empty> 1`] = `Array []`;
+exports[`parse syntax errors .. 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: ".."],
+  },
+]
+`;
+
+exports[`parse syntax errors .a. 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: ".a."],
+  },
+]
+`;
+
+exports[`parse syntax errors <empty> 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: ". There must be at least one pattern present."],
+  },
+]
+`;
+
+exports[`parse syntax errors <whitespace> 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: " . There must be at least one pattern present."],
+  },
+]
+`;
 
 exports[`parse syntax errors @ 1`] = `
 Array [
@@ -388,6 +629,15 @@ Array [
   Object {
     "_tag": "Left",
     "left": [Error: Invalid filter pattern: "a+"],
+  },
+]
+`;
+
+exports[`parse syntax errors a. 1`] = `
+Array [
+  Object {
+    "_tag": "Left",
+    "left": [Error: Invalid filter pattern: "a."],
   },
 ]
 `;

--- a/src/__snapshots__/filter.spec.ts.snap
+++ b/src/__snapshots__/filter.spec.ts.snap
@@ -516,6 +516,26 @@ Array [
 ]
 `;
 
+exports[`parse app1 1`] = `
+Array [
+  Object {
+    "_tag": "Right",
+    "right": Object {
+      "level": Object {
+        "comp": "gte",
+        "value": "trace",
+      },
+      "negate": false,
+      "originalInput": "app1",
+      "path": Object {
+        "descendants": false,
+        "value": ".:app1",
+      },
+    },
+  },
+]
+`;
+
 exports[`parse syntax errors ! 1`] = `
 Array [
   Object {
@@ -706,14 +726,9 @@ Array [
 
 [1m[34mGrammar[39m[22m
 
-    Precise: 
+    [!][[36m<root>[39m](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
 
-    [90m/[39m^(!)?((?:[A-z_]+:)+)?(?:((:)?\\\\*)?|([A-z_]+|))?(?<=\\\\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\\\\*))?$[90m/[39m
-
-    Generally: 
-
-    [!](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
-
+    [36m<root>[39m       = .
     [36m<path>[39m       = [90m/[39m^[A-z_]+[A-z_0-9]*$[90m/[39m [:<path>]
     [36m<levelNum>[39m   = 1     [90m|[39m 2     [90m|[39m 3    [90m|[39m 4    [90m|[39m 5     [90m|[39m 6
     [36m<levelLabel>[39m = trace [90m|[39m debug [90m|[39m info [90m|[39m warn [90m|[39m error [90m|[39m fatal
@@ -768,14 +783,9 @@ Array [
 
 [1m[34mGrammar[39m[22m
 
-    Precise: 
+    [!][[36m<root>[39m](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
 
-    [90m/[39m^(!)?((?:[A-z_]+:)+)?(?:((:)?\\\\*)?|([A-z_]+|))?(?<=\\\\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\\\\*))?$[90m/[39m
-
-    Generally: 
-
-    [!](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
-
+    [36m<root>[39m       = .
     [36m<path>[39m       = [90m/[39m^[A-z_]+[A-z_0-9]*$[90m/[39m [:<path>]
     [36m<levelNum>[39m   = 1     [90m|[39m 2     [90m|[39m 3    [90m|[39m 4    [90m|[39m 5     [90m|[39m 6
     [36m<levelLabel>[39m = trace [90m|[39m debug [90m|[39m info [90m|[39m warn [90m|[39m error [90m|[39m fatal
@@ -830,14 +840,9 @@ Array [
 
 [1m[34mGrammar[39m[22m
 
-    Precise: 
+    [!][[36m<root>[39m](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
 
-    [90m/[39m^(!)?((?:[A-z_]+:)+)?(?:((:)?\\\\*)?|([A-z_]+|))?(?<=\\\\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\\\\*))?$[90m/[39m
-
-    Generally: 
-
-    [!](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
-
+    [36m<root>[39m       = .
     [36m<path>[39m       = [90m/[39m^[A-z_]+[A-z_0-9]*$[90m/[39m [:<path>]
     [36m<levelNum>[39m   = 1     [90m|[39m 2     [90m|[39m 3    [90m|[39m 4    [90m|[39m 5     [90m|[39m 6
     [36m<levelLabel>[39m = trace [90m|[39m debug [90m|[39m info [90m|[39m warn [90m|[39m error [90m|[39m fatal
@@ -889,14 +894,9 @@ Array [
 
 [1m[34mGrammar[39m[22m
 
-    Precise: 
+    [!][[36m<root>[39m](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
 
-    [90m/[39m^(!)?((?:[A-z_]+:)+)?(?:((:)?\\\\*)?|([A-z_]+|))?(?<=\\\\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\\\\*))?$[90m/[39m
-
-    Generally: 
-
-    [!](*|[36m<path>[39m[:*])[@(*|([36m<levelNum>[39m|[36m<levelLabel>[39m)[+-])] [,<pattern>]
-
+    [36m<root>[39m       = .
     [36m<path>[39m       = [90m/[39m^[A-z_]+[A-z_0-9]*$[90m/[39m [:<path>]
     [36m<levelNum>[39m   = 1     [90m|[39m 2     [90m|[39m 3    [90m|[39m 4    [90m|[39m 5     [90m|[39m 6
     [36m<levelLabel>[39m = trace [90m|[39m debug [90m|[39m info [90m|[39m warn [90m|[39m error [90m|[39m fatal

--- a/src/__snapshots__/filter.spec.ts.snap
+++ b/src/__snapshots__/filter.spec.ts.snap
@@ -758,10 +758,14 @@ Array [
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
 
-    [1m[35mWildcard Paths[39m[22m
-    *@*         [90mall paths at all levels[39m
+    [1m[35mExplicit Root[39m[22m
+    .           [90monly logs from the root logger at defualt level[39m
+    .@info      [90monly logs from the root logger at info level[39m
+    .:app       [90mSame as \\"app\\"[39m
+    .:*         [90mSame as \\"*\\"[39m
 
     [1m[35mMixed[39m[22m
+    *@*         [90mall paths at all levels[39m
     app@*       [90mapp path at all levels[39m
     app:*@2+    [90mdescendant paths of app at debug level or higher[39m
     app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
@@ -815,10 +819,14 @@ Array [
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
 
-    [1m[35mWildcard Paths[39m[22m
-    *@*         [90mall paths at all levels[39m
+    [1m[35mExplicit Root[39m[22m
+    .           [90monly logs from the root logger at defualt level[39m
+    .@info      [90monly logs from the root logger at info level[39m
+    .:app       [90mSame as \\"app\\"[39m
+    .:*         [90mSame as \\"*\\"[39m
 
     [1m[35mMixed[39m[22m
+    *@*         [90mall paths at all levels[39m
     app@*       [90mapp path at all levels[39m
     app:*@2+    [90mdescendant paths of app at debug level or higher[39m
     app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
@@ -872,10 +880,14 @@ Array [
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
 
-    [1m[35mWildcard Paths[39m[22m
-    *@*         [90mall paths at all levels[39m
+    [1m[35mExplicit Root[39m[22m
+    .           [90monly logs from the root logger at defualt level[39m
+    .@info      [90monly logs from the root logger at info level[39m
+    .:app       [90mSame as \\"app\\"[39m
+    .:*         [90mSame as \\"*\\"[39m
 
     [1m[35mMixed[39m[22m
+    *@*         [90mall paths at all levels[39m
     app@*       [90mapp path at all levels[39m
     app:*@2+    [90mdescendant paths of app at debug level or higher[39m
     app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
@@ -926,10 +938,14 @@ Array [
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
 
-    [1m[35mWildcard Paths[39m[22m
-    *@*         [90mall paths at all levels[39m
+    [1m[35mExplicit Root[39m[22m
+    .           [90monly logs from the root logger at defualt level[39m
+    .@info      [90monly logs from the root logger at info level[39m
+    .:app       [90mSame as \\"app\\"[39m
+    .:*         [90mSame as \\"*\\"[39m
 
     [1m[35mMixed[39m[22m
+    *@*         [90mall paths at all levels[39m
     app@*       [90mapp path at all levels[39m
     app:*@2+    [90mdescendant paths of app at debug level or higher[39m
     app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 

--- a/src/__snapshots__/filter.spec.ts.snap
+++ b/src/__snapshots__/filter.spec.ts.snap
@@ -735,20 +735,28 @@ Array [
 
 [1m[34mExamples[39m[22m
 
-    [1m[35mPaths[39m[22m
-    app         [90mapp path at default level[39m
-    app:router  [90mapp router path at default level[39m 
+    All logs at...
 
-    [1m[35mWildcards Paths[39m[22m
-    *           [90mall paths at default level[39m 
-    app:*       [90mapp path and its descendant paths at defualt level[39m
-    app::*      [90mdescendant paths of app at defualt level[39m
+    [1m[35mPath[39m[22m
+    app         [90mapp path at default level[39m
+    app:router  [90mapp:router path at default level[39m 
+
+    [1m[35mList[39m[22m
+    app,nexus   [90mapp and nexus paths at default level[39m
+
+    [1m[35mPath Wildcard[39m[22m
+    *           [90many path at default level[39m 
+    app:*       [90mapp path plus descendants at defualt level[39m
+    app::*      [90mapp path descendants at defualt level[39m
 
     [1m[35mNegation[39m[22m
-    !app        [90mall paths expect app at default level[39m 
+    !app      [90many path at any level _except_ those at app path at default level[39m 
+    !*        [90mno path (meaning, nothing will be logged)[39m 
 
-    [1m[35mLists[39m[22m
-    app,nexus   [90mapp and nexus paths at default level[39m
+    [1m[35mRemoval[39m[22m
+    *,!app      [90many path at default level _except_ logs at app path at default level[39m 
+    *,!*@2-     [90many path _except_ those at debug level or lower[39m 
+    app,!app@4  [90mapp path at defualt level _except_ those at warn level[39m 
 
     [1m[35mLevels[39m[22m
     *@info      [90mall paths at info level[39m
@@ -757,18 +765,18 @@ Array [
     *@3         [90mall paths at info level[39m
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
+    app:*@2-    [90mapp path plus descendants at debug level or lower[39m 
+    app::*@2+   [90mapp path descendants at debug level or higher[39m
+
+    [1m[35mLevel Wildcard[39m[22m
+    app@*       [90mapp path at all levels[39m
+    *@*         [90mall paths at all levels[39m
 
     [1m[35mExplicit Root[39m[22m
-    .           [90monly logs from the root logger at defualt level[39m
-    .@info      [90monly logs from the root logger at info level[39m
+    .           [90mroot path at defualt level[39m
+    .@info      [90mroot path at info level[39m
     .:app       [90mSame as \\"app\\"[39m
     .:*         [90mSame as \\"*\\"[39m
-
-    [1m[35mMixed[39m[22m
-    *@*         [90mall paths at all levels[39m
-    app@*       [90mapp path at all levels[39m
-    app:*@2+    [90mdescendant paths of app at debug level or higher[39m
-    app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
   ",
   ],
 ]
@@ -796,20 +804,28 @@ Array [
 
 [1m[34mExamples[39m[22m
 
-    [1m[35mPaths[39m[22m
-    app         [90mapp path at default level[39m
-    app:router  [90mapp router path at default level[39m 
+    All logs at...
 
-    [1m[35mWildcards Paths[39m[22m
-    *           [90mall paths at default level[39m 
-    app:*       [90mapp path and its descendant paths at defualt level[39m
-    app::*      [90mdescendant paths of app at defualt level[39m
+    [1m[35mPath[39m[22m
+    app         [90mapp path at default level[39m
+    app:router  [90mapp:router path at default level[39m 
+
+    [1m[35mList[39m[22m
+    app,nexus   [90mapp and nexus paths at default level[39m
+
+    [1m[35mPath Wildcard[39m[22m
+    *           [90many path at default level[39m 
+    app:*       [90mapp path plus descendants at defualt level[39m
+    app::*      [90mapp path descendants at defualt level[39m
 
     [1m[35mNegation[39m[22m
-    !app        [90mall paths expect app at default level[39m 
+    !app      [90many path at any level _except_ those at app path at default level[39m 
+    !*        [90mno path (meaning, nothing will be logged)[39m 
 
-    [1m[35mLists[39m[22m
-    app,nexus   [90mapp and nexus paths at default level[39m
+    [1m[35mRemoval[39m[22m
+    *,!app      [90many path at default level _except_ logs at app path at default level[39m 
+    *,!*@2-     [90many path _except_ those at debug level or lower[39m 
+    app,!app@4  [90mapp path at defualt level _except_ those at warn level[39m 
 
     [1m[35mLevels[39m[22m
     *@info      [90mall paths at info level[39m
@@ -818,18 +834,18 @@ Array [
     *@3         [90mall paths at info level[39m
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
+    app:*@2-    [90mapp path plus descendants at debug level or lower[39m 
+    app::*@2+   [90mapp path descendants at debug level or higher[39m
+
+    [1m[35mLevel Wildcard[39m[22m
+    app@*       [90mapp path at all levels[39m
+    *@*         [90mall paths at all levels[39m
 
     [1m[35mExplicit Root[39m[22m
-    .           [90monly logs from the root logger at defualt level[39m
-    .@info      [90monly logs from the root logger at info level[39m
+    .           [90mroot path at defualt level[39m
+    .@info      [90mroot path at info level[39m
     .:app       [90mSame as \\"app\\"[39m
     .:*         [90mSame as \\"*\\"[39m
-
-    [1m[35mMixed[39m[22m
-    *@*         [90mall paths at all levels[39m
-    app@*       [90mapp path at all levels[39m
-    app:*@2+    [90mdescendant paths of app at debug level or higher[39m
-    app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
   ",
   ],
 ]
@@ -857,20 +873,28 @@ Array [
 
 [1m[34mExamples[39m[22m
 
-    [1m[35mPaths[39m[22m
-    app         [90mapp path at default level[39m
-    app:router  [90mapp router path at default level[39m 
+    All logs at...
 
-    [1m[35mWildcards Paths[39m[22m
-    *           [90mall paths at default level[39m 
-    app:*       [90mapp path and its descendant paths at defualt level[39m
-    app::*      [90mdescendant paths of app at defualt level[39m
+    [1m[35mPath[39m[22m
+    app         [90mapp path at default level[39m
+    app:router  [90mapp:router path at default level[39m 
+
+    [1m[35mList[39m[22m
+    app,nexus   [90mapp and nexus paths at default level[39m
+
+    [1m[35mPath Wildcard[39m[22m
+    *           [90many path at default level[39m 
+    app:*       [90mapp path plus descendants at defualt level[39m
+    app::*      [90mapp path descendants at defualt level[39m
 
     [1m[35mNegation[39m[22m
-    !app        [90mall paths expect app at default level[39m 
+    !app      [90many path at any level _except_ those at app path at default level[39m 
+    !*        [90mno path (meaning, nothing will be logged)[39m 
 
-    [1m[35mLists[39m[22m
-    app,nexus   [90mapp and nexus paths at default level[39m
+    [1m[35mRemoval[39m[22m
+    *,!app      [90many path at default level _except_ logs at app path at default level[39m 
+    *,!*@2-     [90many path _except_ those at debug level or lower[39m 
+    app,!app@4  [90mapp path at defualt level _except_ those at warn level[39m 
 
     [1m[35mLevels[39m[22m
     *@info      [90mall paths at info level[39m
@@ -879,18 +903,18 @@ Array [
     *@3         [90mall paths at info level[39m
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
+    app:*@2-    [90mapp path plus descendants at debug level or lower[39m 
+    app::*@2+   [90mapp path descendants at debug level or higher[39m
+
+    [1m[35mLevel Wildcard[39m[22m
+    app@*       [90mapp path at all levels[39m
+    *@*         [90mall paths at all levels[39m
 
     [1m[35mExplicit Root[39m[22m
-    .           [90monly logs from the root logger at defualt level[39m
-    .@info      [90monly logs from the root logger at info level[39m
+    .           [90mroot path at defualt level[39m
+    .@info      [90mroot path at info level[39m
     .:app       [90mSame as \\"app\\"[39m
     .:*         [90mSame as \\"*\\"[39m
-
-    [1m[35mMixed[39m[22m
-    *@*         [90mall paths at all levels[39m
-    app@*       [90mapp path at all levels[39m
-    app:*@2+    [90mdescendant paths of app at debug level or higher[39m
-    app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
   ",
   ],
 ]
@@ -915,20 +939,28 @@ Array [
 
 [1m[34mExamples[39m[22m
 
-    [1m[35mPaths[39m[22m
-    app         [90mapp path at default level[39m
-    app:router  [90mapp router path at default level[39m 
+    All logs at...
 
-    [1m[35mWildcards Paths[39m[22m
-    *           [90mall paths at default level[39m 
-    app:*       [90mapp path and its descendant paths at defualt level[39m
-    app::*      [90mdescendant paths of app at defualt level[39m
+    [1m[35mPath[39m[22m
+    app         [90mapp path at default level[39m
+    app:router  [90mapp:router path at default level[39m 
+
+    [1m[35mList[39m[22m
+    app,nexus   [90mapp and nexus paths at default level[39m
+
+    [1m[35mPath Wildcard[39m[22m
+    *           [90many path at default level[39m 
+    app:*       [90mapp path plus descendants at defualt level[39m
+    app::*      [90mapp path descendants at defualt level[39m
 
     [1m[35mNegation[39m[22m
-    !app        [90mall paths expect app at default level[39m 
+    !app      [90many path at any level _except_ those at app path at default level[39m 
+    !*        [90mno path (meaning, nothing will be logged)[39m 
 
-    [1m[35mLists[39m[22m
-    app,nexus   [90mapp and nexus paths at default level[39m
+    [1m[35mRemoval[39m[22m
+    *,!app      [90many path at default level _except_ logs at app path at default level[39m 
+    *,!*@2-     [90many path _except_ those at debug level or lower[39m 
+    app,!app@4  [90mapp path at defualt level _except_ those at warn level[39m 
 
     [1m[35mLevels[39m[22m
     *@info      [90mall paths at info level[39m
@@ -937,18 +969,18 @@ Array [
     *@3         [90mall paths at info level[39m
     *@4-        [90mall paths at error level or lower[39m
     *@2+        [90mall paths at debug level or higher[39m
+    app:*@2-    [90mapp path plus descendants at debug level or lower[39m 
+    app::*@2+   [90mapp path descendants at debug level or higher[39m
+
+    [1m[35mLevel Wildcard[39m[22m
+    app@*       [90mapp path at all levels[39m
+    *@*         [90mall paths at all levels[39m
 
     [1m[35mExplicit Root[39m[22m
-    .           [90monly logs from the root logger at defualt level[39m
-    .@info      [90monly logs from the root logger at info level[39m
+    .           [90mroot path at defualt level[39m
+    .@info      [90mroot path at info level[39m
     .:app       [90mSame as \\"app\\"[39m
     .:*         [90mSame as \\"*\\"[39m
-
-    [1m[35mMixed[39m[22m
-    *@*         [90mall paths at all levels[39m
-    app@*       [90mapp path at all levels[39m
-    app:*@2+    [90mdescendant paths of app at debug level or higher[39m
-    app*@2-     [90mapp & descendant paths of app at debug level or lower[39m 
   ",
   ],
 ]

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -45,6 +45,7 @@ describe('parse', () => {
   // paths
   it('a',       () => { expect(parse('a')).toMatchSnapshot() })
   it('a:b',     () => { expect(parse('a:b')).toMatchSnapshot() })
+  it('app1',    () => { expect(parse('app1')).toMatchSnapshot() })
   // lists
   it('a,b',     () => { expect(parse('a,b')).toMatchSnapshot() })
   it(',,a,b',   () => { expect(parse(',,a,b')).toMatchSnapshot() })

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -119,6 +119,7 @@ describe('test', () => {
     [defaults, '*@*', rec(), true],
     // negate
     [defaults, '!foo', rec({ path: ['foo'] }), false],
+    [defaults, '.,!app', rec({ path: ['foo'], level: 1 }), false],
     [defaults, '!foo', rec({ path: ['foo', 'bar'] }), true],
     // negate + wildcard
     [defaults, '!foo:*', rec({ path: ['foo'] }), false],
@@ -142,7 +143,7 @@ describe('test', () => {
     // misc
     // filtered out by later pattern
     [defaults, 'foo:*,!foo:bar', rec({ path: ['foo', 'bar'] }), false],
-    [defaults, 'foo,!foo', rec({ path: ['foo'] }), false],
+    // [defaults, 'foo,!foo', rec({ path: ['foo'] }), false],
     // defaults
     [{ level: { comp: 'eq', value: 'debug' } }, '*', rec({ level: 1 }), false],
     [{ level: { comp: 'eq', value: 'debug' } }, 'foo', rec({ path: ['foo'], level: 3 }), false],

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -28,16 +28,18 @@ function parse(pattern: string) {
 
 // prettier-ignore
 describe('parse', () => {
+  // root
+  it('.',       () => { expect(parse('.')).toMatchSnapshot() })
   // wildcards
   it('*',       () => { expect(parse('*')).toMatchSnapshot() })
   it('*@*',     () => { expect(parse('*@*')).toMatchSnapshot() })
   it('*@1',     () => { expect(parse('*@1')).toMatchSnapshot() })
-  it('app:*',    () => { expect(parse('app*')).toMatchSnapshot() })
+  it('app:*',   () => { expect(parse('app:*')).toMatchSnapshot() })
   it('app@*',   () => { expect(parse('app@*')).toMatchSnapshot() })
-  it('app:*@*',  () => { expect(parse('app*@*')).toMatchSnapshot() })
-  it('app:*@1',  () => { expect(parse('app*@*')).toMatchSnapshot() })
+  it('app:*@*', () => { expect(parse('app:*@*')).toMatchSnapshot() })
+  it('app:*@1', () => { expect(parse('app:*@*')).toMatchSnapshot() })
   // wildcards exclusive
-  it('app::*',    () => { expect(parse('app::*')).toMatchSnapshot() })
+  it('app::*',  () => { expect(parse('app::*')).toMatchSnapshot() })
   // negate
   it('!a',      () => { expect(parse('!a')).toMatchSnapshot() })
   // paths
@@ -70,13 +72,23 @@ describe('parse', () => {
   })
   // wildcard/levels + paths
   it('a:b:*',       () => { expect(parse('a:b:*')).toMatchSnapshot() })
-  it('a:b:*@info',       () => { expect(parse('a:b:@1')).toMatchSnapshot() })
+  it('a:b:*@info',       () => { expect(parse('a:b:*@1')).toMatchSnapshot() })
+  // root integration
+  it('.:*',       () => { expect(parse('.:*')).toMatchSnapshot() })
+  it('.::*',       () => { expect(parse('.::*')).toMatchSnapshot() })
+  it('.@*',       () => { expect(parse('.@*')).toMatchSnapshot() })
+  it('.:*@1',       () => { expect(parse('.:*@1')).toMatchSnapshot() })
+  it('.:a',       () => { expect(parse('.:a')).toMatchSnapshot() })
+  it('.:a:*',       () => { expect(parse('.:a:*')).toMatchSnapshot() })
 })
 
 // prettier-ignore
 describe('parse syntax errors', () => {
-
+  // empty patterns
+  it('<whitespace>', () => { expect(parse(' ')).toMatchSnapshot() })
   it('<empty>', () => { expect(parse('')).toMatchSnapshot() })
+  it(',', () => { expect(parse(',')).toMatchSnapshot() })
+  // other
   it('**', () => { expect(parse('**')).toMatchSnapshot() })
   it('*a', () => { expect(parse('*a')).toMatchSnapshot() })
   it('*+', () => { expect(parse('*+')).toMatchSnapshot() })
@@ -84,7 +96,6 @@ describe('parse syntax errors', () => {
   it('@', () => { expect(parse('@')).toMatchSnapshot() })
   it('a@*-', () => { expect(parse('a@*-')).toMatchSnapshot() })
   it('a@*+', () => { expect(parse('a@*+')).toMatchSnapshot() })
-  it(',', () => { expect(parse(',')).toMatchSnapshot() })
   it('a@+*', () => { expect(parse('a@+*')).toMatchSnapshot() })
   it('a+', () => { expect(parse('a+')).toMatchSnapshot() })
   it('!', () => { expect(parse('!')).toMatchSnapshot() })
@@ -92,6 +103,9 @@ describe('parse syntax errors', () => {
   it('a@*!', () => { expect(parse('a@*!')).toMatchSnapshot() })
   it('@1', () => { expect(parse('@1')).toMatchSnapshot() })
   it('a:@1', () => { expect(parse('a:@1')).toMatchSnapshot() })
+  it('..', () => { expect(parse('..')).toMatchSnapshot() })
+  it('.a.', () => { expect(parse('.a.')).toMatchSnapshot() })
+  it('a.', () => { expect(parse('a.')).toMatchSnapshot() })
 })
 
 describe('test', () => {
@@ -100,6 +114,7 @@ describe('test', () => {
   it.each([
     // wildcard
     [defaults, '*', rec(), true],
+    [defaults, ':*', rec(), false],
     [defaults, '*@*', rec(), true],
     // negate
     [defaults, '!foo', rec({ path: ['foo'] }), false],
@@ -182,7 +197,6 @@ describe('processLogFilterInput', () => {
 function rec(data?: Partial<Pick<LogRecord, 'level' | 'path'>>): LogRecord {
   return {
     // overridable
-    path: ['root'],
     level: 1,
     // overrides
     ...data,

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -119,12 +119,18 @@ describe('test', () => {
     [defaults, '*@*', rec(), true],
     // negate
     [defaults, '!foo', rec({ path: ['foo'] }), false],
-    [defaults, '.,!app', rec({ path: ['foo'], level: 1 }), false],
     [defaults, '!foo', rec({ path: ['foo', 'bar'] }), true],
+    [defaults, '!foo', rec({ path: ['a'] }), true],
+    // removal
+    [defaults, 'a,!a', rec({ path: ['a'] }), false],
+    [defaults, 'a,!a,a', rec({ path: ['a'] }), true],
+    [defaults, '*@2+,!app', rec({ path: ['foo'], level: 1 }), false],
     // negate + wildcard
     [defaults, '!foo:*', rec({ path: ['foo'] }), false],
     [defaults, '!foo::*', rec({ path: ['foo'] }), true],
     [defaults, '!foo::*', rec({ path: ['foo', 'bar'] }), false],
+    [defaults, 'app,!app@4', rec({ path: ['app'], level: 3 }), true],
+    [defaults, 'app,!app@4', rec({ path: ['app'], level: 4 }), false],
     // level
     [defaults, '*@2', rec({ level: 1 }), false],
     [defaults, '*@fatal', rec({ level: 6 }), true],

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -5,17 +5,11 @@ import * as Level from './level'
 import type { LogRecord } from './logger'
 import { casesHandled, ContextualError, createContextualError, getLeft, rightOrThrow } from './utils'
 
-// https://regex101.com/r/6g6BHc/5
-// If you change the regex please update the link and vice-versa!
-const validPatternRegex = /^(!)?((?:[A-z_]+:)+)?(?:((:)?\*)?|([A-z_]+|))?(?<=\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\*))?$/
+// failed to get a singular regex solution https://regex101.com/r/6g6BHc/6
+// const validPattern = '...'
 
-// parse !
-// parse :::::
-// check for leading '.'
-// strip it if preset
-// check for trailing ['', '<stuff>']
-// va
-// parse <stuff>
+// https://regex101.com/r/6g6BHc/9
+const validTargetRegex = /^((?:[A-z_]+[A-z_0-9]*)+|\*|\.)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\*))?$/
 
 const symbols = {
   negate: '!',
@@ -87,9 +81,6 @@ export function parseOne(criteriaDefaults: Defaults, pattern: string): Either<Pa
     return left(createInvalidPattern(originalInput))
   }
 
-  // failed to get a singular regex solution https://regex101.com/r/6g6BHc/6
-  // const match = pattern.match(validPatternRegex)
-
   const negate = pattern[0] === '!'
   if (negate) {
     pattern = pattern.slice(1)
@@ -113,10 +104,7 @@ export function parseOne(criteriaDefaults: Defaults, pattern: string): Either<Pa
 
   const prefix = parts.join(':')
 
-  // https://regex101.com/r/6g6BHc/8
-  const targetm = target.match(
-    /^([A-z_]+|\*|\.)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\*))?$/
-  )
+  const targetm = target.match(validTargetRegex)
 
   if (!targetm) {
     return left(createInvalidPattern(originalInput))
@@ -330,14 +318,9 @@ ${bold(b(`▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬�
 
 ${bold(b(`Grammar`))}
 
-    Precise: 
+    [!][${c(`<root>`)}](*|${c(`<path>`)}[:*])[@(*|(${c(`<levelNum>`)}|${c(`<levelLabel>`)})[+-])] [,<pattern>]
 
-    ${validPatternRegex.toString().replace(/(^\/|\/$)/g, gray(`$1`))}
-
-    Generally: 
-
-    [!](*|${c(`<path>`)}[:*])[@(*|(${c(`<levelNum>`)}|${c(`<levelLabel>`)})[+-])] [,<pattern>]
-
+    ${c(`<root>`)}       = .
     ${c(`<path>`)}       = ${validPathSegmentNameRegex.toString().replace(/(^\/|\/$)/g, gray(`$1`))} [:<path>]
     ${c(`<levelNum>`)}   = 1     ${pipe} 2     ${pipe} 3    ${pipe} 4    ${pipe} 5     ${pipe} 6
     ${c(`<levelLabel>`)} = trace ${pipe} debug ${pipe} info ${pipe} warn ${pipe} error ${pipe} fatal

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -350,10 +350,14 @@ ${bold(b(`Examples`))}
     *@4-        ${subtle(`all paths at error level or lower`)}
     *@2+        ${subtle(`all paths at debug level or higher`)}
 
-    ${subtitle(`Wildcard Paths`)}
-    *@*         ${subtle(`all paths at all levels`)}
+    ${subtitle(`Explicit Root`)}
+    .           ${subtle(`only logs from the root logger at defualt level`)}
+    .@info      ${subtle(`only logs from the root logger at info level`)}
+    .:app       ${subtle(`Same as "app"`)}
+    .:*         ${subtle(`Same as "*"`)}
 
     ${subtitle(`Mixed`)}
+    *@*         ${subtle(`all paths at all levels`)}
     app@*       ${subtle(`app path at all levels`)}
     app:*@2+    ${subtle(`descendant paths of app at debug level or higher`)}
     app*@2-     ${subtle(`app & descendant paths of app at debug level or lower`)} 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -168,7 +168,7 @@ export function test(patterns: Readonly<Parsed[]>, log: LogRecord): boolean {
     // if log already passed then we can skip rest except negations
     if (yaynay && !pattern.negate) continue
 
-    const logPath = log.path.join(symbols.pathDelim)
+    const logPath = log.path?.join(symbols.pathDelim) ?? null
     let isPass = false
 
     // test in order of computational cost, short-citcuiting ASAP
@@ -187,6 +187,8 @@ export function test(patterns: Readonly<Parsed[]>, log: LogRecord): boolean {
       if (pattern.path.descendents) {
         if (logPath === pattern.path.value) {
           isPass = pattern.path.descendents.includeParent
+        } else if (logPath === null) {
+          isPass = false
         } else {
           isPass = logPath.startsWith(pattern.path.value)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 export { demo } from './demo'
 export { Logger } from './logger'
-export { create, RootLogger } from './root-logger'
+export { RootLogger } from './root-logger'
 export { Data as SettingsData, Input as SettingsInput } from './settings'
+
+import { create } from './root-logger'
+
+export const log = create()

--- a/src/own-logger.ts
+++ b/src/own-logger.ts
@@ -1,3 +1,3 @@
 import * as Logger from './'
 
-export const log = Logger.create({ name: 'nexusLogger' })
+export const log = Logger.log.child('nexusLogger')

--- a/src/prettifier.ts
+++ b/src/prettifier.ts
@@ -163,9 +163,11 @@ export function render(opts: Options, logRecord: Logger.LogRecord): string {
   // pre-emptyive measurement for potential multiline context indentation later on
   const gutterWidth = timeDiff.length + style.badge.length + levelLabelSized.length
 
-  //
-  // render pre-context
-  //
+  /**
+   * Render Pre-Context
+   *
+   * Path is null when log came from root.
+   */
 
   const path = logRecord.path?.join(renderEl(separators.path)) ?? ''
   const preContextWidth = path

--- a/src/prettifier.ts
+++ b/src/prettifier.ts
@@ -167,9 +167,13 @@ export function render(opts: Options, logRecord: Logger.LogRecord): string {
   // render pre-context
   //
 
-  const path = logRecord.path.join(renderEl(separators.path))
-  const preContextWidth = path.length + separators.event.symbol.length + logRecord.event.length
-  const preContextRendered = style.color(path) + renderEl(separators.event) + logRecord.event
+  const path = logRecord.path?.join(renderEl(separators.path)) ?? ''
+  const preContextWidth = path
+    ? path.length + separators.event.symbol.length + logRecord.event.length
+    : logRecord.event.length
+  const preContextRendered = path
+    ? style.color(path) + renderEl(separators.event) + logRecord.event
+    : logRecord.event
 
   //
   // render context

--- a/src/root-logger.ts
+++ b/src/root-logger.ts
@@ -6,9 +6,7 @@ export type SettingsManager = Settings.Data & {
 }
 
 // TODO jsDoc for each option
-export type Options = Settings.Input & {
-  name?: string
-}
+export type Options = Settings.Input
 
 export type RootLogger = Logger.Logger & {
   settings: SettingsManager
@@ -29,7 +27,7 @@ export function create(opts?: Options): RootLogger {
     return logger
   }) as SettingsManager
   Object.assign(settingsManager, settings)
-  const loggerLink = Logger.create({ settings: settingsManager }, [opts?.name ?? 'root'], {})
+  const loggerLink = Logger.create({ settings: settingsManager }, null, {})
   const logger = loggerLink.logger as RootLogger
   logger.settings = settingsManager
   return logger

--- a/tests/__snapshots__/rest.spec.ts.snap
+++ b/tests/__snapshots__/rest.spec.ts.snap
@@ -10,9 +10,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -20,9 +17,6 @@ Array [
     "context": Object {},
     "event": "bye",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -35,9 +29,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 6,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -45,9 +36,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 5,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -55,9 +43,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 4,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -65,9 +50,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -75,9 +57,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 2,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -85,9 +64,6 @@ Array [
     "context": Object {},
     "event": "hi",
     "level": 1,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -105,9 +81,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -125,9 +98,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -144,9 +114,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -163,9 +130,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },
@@ -179,7 +143,6 @@ Array [
     "event": "hi",
     "level": 3,
     "path": Array [
-      "root",
       "tim",
     ],
     "pid": 0,
@@ -195,7 +158,6 @@ Array [
     "event": "hi",
     "level": 1,
     "path": Array [
-      "root",
       "tim",
     ],
     "pid": 0,
@@ -214,7 +176,6 @@ Array [
     "event": "foo",
     "level": 3,
     "path": Array [
-      "root",
       "b1",
     ],
     "pid": 0,
@@ -228,7 +189,6 @@ Array [
     "event": "foo",
     "level": 3,
     "path": Array [
-      "root",
       "b2",
     ],
     "pid": 0,
@@ -242,7 +202,6 @@ Array [
     "event": "foo",
     "level": 3,
     "path": Array [
-      "root",
       "b3",
     ],
     "pid": 0,
@@ -258,7 +217,6 @@ Array [
     "event": "foo",
     "level": 1,
     "path": Array [
-      "root",
       "b",
     ],
     "pid": 0,
@@ -273,9 +231,6 @@ Array [
     "context": Object {},
     "event": "foo",
     "level": 6,
-    "path": Array [
-      "root",
-    ],
     "pid": 0,
     "time": 0,
   },

--- a/tests/__snapshots__/settings.spec.ts.snap
+++ b/tests/__snapshots__/settings.spec.ts.snap
@@ -154,22 +154,22 @@ Object {
 
 exports[`pretty .color controls if pretty logs have color or not 1`] = `
 Array [
-  "● root foo  --  qux: true
+  "● foo  --  qux: true
 ",
 ]
 `;
 
 exports[`pretty .levelLabel controls if label is spelt out or not 1`] = `
 Array [
-  "✕ fatal root foo
+  "✕ fatal foo
 ",
-  "■ error root foo
+  "■ error foo
 ",
-  "▲ warn  root foo
+  "▲ warn  foo
 ",
-  "● info  root foo
+  "● info  foo
 ",
-  "○ debug root foo
+  "○ debug foo
 ",
 ]
 `;

--- a/tests/__snapshots__/settings.spec.ts.snap
+++ b/tests/__snapshots__/settings.spec.ts.snap
@@ -42,10 +42,14 @@ Examples
     *@4-        all paths at error level or lower
     *@2+        all paths at debug level or higher
 
-    Wildcard Paths
-    *@*         all paths at all levels
+    Explicit Root
+    .           only logs from the root logger at defualt level
+    .@info      only logs from the root logger at info level
+    .:app       Same as \\"app\\"
+    .:*         Same as \\"*\\"
 
     Mixed
+    *@*         all paths at all levels
     app@*       app path at all levels
     app:*@2+    descendant paths of app at debug level or higher
     app*@2-     app & descendant paths of app at debug level or lower 

--- a/tests/__snapshots__/settings.spec.ts.snap
+++ b/tests/__snapshots__/settings.spec.ts.snap
@@ -19,20 +19,28 @@ Grammar
 
 Examples
 
-    Paths
-    app         app path at default level
-    app:router  app router path at default level 
+    All logs at...
 
-    Wildcards Paths
-    *           all paths at default level 
-    app:*       app path and its descendant paths at defualt level
-    app::*      descendant paths of app at defualt level
+    Path
+    app         app path at default level
+    app:router  app:router path at default level 
+
+    List
+    app,nexus   app and nexus paths at default level
+
+    Path Wildcard
+    *           any path at default level 
+    app:*       app path plus descendants at defualt level
+    app::*      app path descendants at defualt level
 
     Negation
-    !app        all paths expect app at default level 
+    !app      any path at any level _except_ those at app path at default level 
+    !*        no path (meaning, nothing will be logged) 
 
-    Lists
-    app,nexus   app and nexus paths at default level
+    Removal
+    *,!app      any path at default level _except_ logs at app path at default level 
+    *,!*@2-     any path _except_ those at debug level or lower 
+    app,!app@4  app path at defualt level _except_ those at warn level 
 
     Levels
     *@info      all paths at info level
@@ -41,18 +49,18 @@ Examples
     *@3         all paths at info level
     *@4-        all paths at error level or lower
     *@2+        all paths at debug level or higher
+    app:*@2-    app path plus descendants at debug level or lower 
+    app::*@2+   app path descendants at debug level or higher
+
+    Level Wildcard
+    app@*       app path at all levels
+    *@*         all paths at all levels
 
     Explicit Root
-    .           only logs from the root logger at defualt level
-    .@info      only logs from the root logger at info level
+    .           root path at defualt level
+    .@info      root path at info level
     .:app       Same as \\"app\\"
     .:*         Same as \\"*\\"
-
-    Mixed
-    *@*         all paths at all levels
-    app@*       app path at all levels
-    app:*@2+    descendant paths of app at debug level or higher
-    app*@2-     app & descendant paths of app at debug level or lower 
   ",
   ],
 ]

--- a/tests/__snapshots__/settings.spec.ts.snap
+++ b/tests/__snapshots__/settings.spec.ts.snap
@@ -70,7 +70,7 @@ Array [
     "originalInput": "foo",
     "path": Object {
       "descendants": false,
-      "value": "foo",
+      "value": ".:foo",
     },
   },
 ]
@@ -95,7 +95,7 @@ Object {
       "originalInput": "from_env_var",
       "path": Object {
         "descendants": false,
-        "value": "from_env_var",
+        "value": ".:from_env_var",
       },
     },
   ],
@@ -123,7 +123,7 @@ Object {
         "descendants": Object {
           "includeParent": true,
         },
-        "value": null,
+        "value": ".",
       },
     },
   ],
@@ -151,7 +151,7 @@ Object {
         "descendants": Object {
           "includeParent": true,
         },
-        "value": null,
+        "value": ".",
       },
     },
   ],

--- a/tests/__snapshots__/settings.spec.ts.snap
+++ b/tests/__snapshots__/settings.spec.ts.snap
@@ -10,14 +10,9 @@ LOG FILTERING SYNTAX MANUAL  ⟁
 
 Grammar
 
-    Precise: 
+    [!][<root>](*|<path>[:*])[@(*|(<levelNum>|<levelLabel>)[+-])] [,<pattern>]
 
-    /^(!)?((?:[A-z_]+:)+)?(?:((:)?\\\\*)?|([A-z_]+|))?(?<=\\\\*|[A-z_]+)(?:(?:@(1|2|3|4|5|6|trace|debug|info|warn|error|fatal)([-+]?))|(@\\\\*))?$/
-
-    Generally: 
-
-    [!](*|<path>[:*])[@(*|(<levelNum>|<levelLabel>)[+-])] [,<pattern>]
-
+    <root>       = .
     <path>       = /^[A-z_]+[A-z_0-9]*$/ [:<path>]
     <levelNum>   = 1     | 2     | 3    | 4    | 5     | 6
     <levelLabel> = trace | debug | info | warn | error | fatal

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1,4 +1,5 @@
 import * as Logger from '../src'
+import * as RootLogger from '../src/root-logger'
 import {
   createMockOutput,
   mockConsoleLog,
@@ -15,17 +16,17 @@ resetBeforeEachTest(process, 'env')
 beforeEach(() => {
   process.env.LOG_PRETTY = 'false'
   output = createMockOutput()
-  log = Logger.create({ output, pretty: { timeDiff: false } })
+  log = RootLogger.create({ output, pretty: { timeDiff: false } })
   process.stdout.columns = 200
 })
 
 describe('pretty', () => {
   describe('.enabled', () => {
     it('can be disabled', () => {
-      expect(Logger.create({ pretty: { enabled: false } }).settings.pretty.enabled).toEqual(false)
+      expect(RootLogger.create({ pretty: { enabled: false } }).settings.pretty.enabled).toEqual(false)
     })
     it('persists across peer field changes', () => {
-      const l = Logger.create({ pretty: { enabled: false } })
+      const l = RootLogger.create({ pretty: { enabled: false } })
       l.settings({ pretty: { color: false } })
       expect(l.settings.pretty).toEqual({
         enabled: false,
@@ -45,26 +46,26 @@ describe('pretty', () => {
       it('considers instnace time config first', () => {
         process.stdout.isTTY = false
         process.env.LOG_PRETTY = 'false'
-        const l = Logger.create({ pretty: false })
+        const l = RootLogger.create({ pretty: false })
         l.settings({ pretty: true })
         expect(l.settings.pretty.enabled).toEqual(true)
       })
       it('then considers construction time config', () => {
         process.stdout.isTTY = false
         process.env.LOG_PRETTY = 'false'
-        const l = Logger.create({ pretty: true })
+        const l = RootLogger.create({ pretty: true })
         expect(l.settings.pretty.enabled).toEqual(true)
       })
       it('then considers LOG_PRETTY env var true|false (case insensitive)', () => {
         process.stdout.isTTY = false
         process.env.LOG_PRETTY = 'tRuE'
-        const l = Logger.create()
+        const l = RootLogger.create()
         expect(l.settings.pretty.enabled).toEqual(true)
       })
       it('then defaults to process.stdout.isTTY', () => {
         delete process.env.LOG_PRETTY // pre-test logic forces false otherwise
         process.stdout.isTTY = true
-        const l = Logger.create()
+        const l = RootLogger.create()
         expect(l.settings.pretty.enabled).toEqual(true)
       })
     })
@@ -77,16 +78,18 @@ describe('pretty', () => {
       expect(output.memory.jsonOrRaw).toMatchSnapshot()
     })
     it('can be disabled', () => {
-      expect(Logger.create({ pretty: { enabled: false, color: false } }).settings.pretty.color).toEqual(false)
+      expect(RootLogger.create({ pretty: { enabled: false, color: false } }).settings.pretty.color).toEqual(
+        false
+      )
     })
     it('is true by default', () => {
-      expect(Logger.create({ pretty: { enabled: true } }).settings.pretty).toEqual({
+      expect(RootLogger.create({ pretty: { enabled: true } }).settings.pretty).toEqual({
         enabled: true,
         color: true,
         levelLabel: false,
         timeDiff: true,
       })
-      expect(Logger.create({ pretty: { enabled: false } }).settings.pretty).toEqual({
+      expect(RootLogger.create({ pretty: { enabled: false } }).settings.pretty).toEqual({
         enabled: false,
         color: true,
         levelLabel: false,
@@ -94,7 +97,7 @@ describe('pretty', () => {
       })
     })
     it('persists across peer field changes', () => {
-      const l = Logger.create({
+      const l = RootLogger.create({
         pretty: { enabled: false, color: false },
       })
       l.settings({ pretty: { enabled: true } })
@@ -108,16 +111,16 @@ describe('pretty', () => {
   })
   describe('.levelLabel', () => {
     it('is false by default', () => {
-      expect(Logger.create().settings.pretty.levelLabel).toEqual(false)
+      expect(RootLogger.create().settings.pretty.levelLabel).toEqual(false)
     })
     it('can be enabled', () => {
-      expect(Logger.create({ pretty: { levelLabel: true } }).settings.pretty.levelLabel).toEqual(true)
-      expect(Logger.create().settings({ pretty: { levelLabel: true } }).settings.pretty.levelLabel).toEqual(
-        true
-      )
+      expect(RootLogger.create({ pretty: { levelLabel: true } }).settings.pretty.levelLabel).toEqual(true)
+      expect(
+        RootLogger.create().settings({ pretty: { levelLabel: true } }).settings.pretty.levelLabel
+      ).toEqual(true)
     })
     it('persists across peer field changes', () => {
-      const l = Logger.create({ pretty: { levelLabel: true } })
+      const l = RootLogger.create({ pretty: { levelLabel: true } })
       l.settings({ pretty: false })
       expect(l.settings.pretty.levelLabel).toBe(true)
     })
@@ -136,17 +139,17 @@ describe('pretty', () => {
   })
   describe('.timeDiff', () => {
     it('is true by default', () => {
-      expect(Logger.create().settings.pretty.timeDiff).toEqual(true)
+      expect(RootLogger.create().settings.pretty.timeDiff).toEqual(true)
     })
     it('can be disabled', () => {
-      const l1 = Logger.create({ pretty: { timeDiff: false } })
+      const l1 = RootLogger.create({ pretty: { timeDiff: false } })
       expect(l1.settings.pretty.timeDiff).toEqual(false)
-      const l2 = Logger.create()
+      const l2 = RootLogger.create()
       l2.settings({ pretty: { timeDiff: false } })
       expect(l2.settings.pretty.levelLabel).toEqual(false)
     })
     it('persists across peer field changes', () => {
-      const l = Logger.create({ pretty: { timeDiff: false } })
+      const l = RootLogger.create({ pretty: { timeDiff: false } })
       l.settings({ pretty: false })
       expect(l.settings.pretty.timeDiff).toBe(false)
     })
@@ -172,7 +175,7 @@ describe('pretty', () => {
 
   describe('shorthands', () => {
     it('true means enabled true', () => {
-      expect(Logger.create({ pretty: true }).settings.pretty).toEqual({
+      expect(RootLogger.create({ pretty: true }).settings.pretty).toEqual({
         enabled: true,
         color: true,
         levelLabel: false,
@@ -181,7 +184,7 @@ describe('pretty', () => {
     })
 
     it('false means enabled false', () => {
-      expect(Logger.create({ pretty: false }).settings.pretty).toEqual({
+      expect(RootLogger.create({ pretty: false }).settings.pretty).toEqual({
         enabled: false,
         color: true,
         levelLabel: false,
@@ -195,31 +198,31 @@ describe('filter', () => {
   describe('precedence', () => {
     it('considers instance time config first', () => {
       process.env.LOG_FILTER = 'from_env_var'
-      const l = Logger.create({ filter: { pattern: '*@fatal' } })
+      const l = RootLogger.create({ filter: { pattern: '*@fatal' } })
       l.settings({ filter: { pattern: 'foo' } })
       expect(l.settings.filter.patterns).toMatchSnapshot()
     })
 
     it('then considers construction time config', () => {
       process.env.LOG_FILTER = 'from_env_var'
-      const l = Logger.create({ filter: { pattern: '*@fatal' } })
+      const l = RootLogger.create({ filter: { pattern: '*@fatal' } })
       expect(l.settings.filter).toMatchSnapshot()
     })
 
     it('then considers LOG_FILTER env var', () => {
       process.env.LOG_FILTER = 'from_env_var'
-      const l = Logger.create()
+      const l = RootLogger.create()
       expect(l.settings.filter).toMatchSnapshot()
     })
 
     it('then defaults to "*', () => {
-      const l = Logger.create()
+      const l = RootLogger.create()
       expect(l.settings.filter).toMatchSnapshot()
     })
   })
 
   it('can be passed a pattern directly', () => {
-    const l = Logger.create({ filter: '*@fatal' })
+    const l = RootLogger.create({ filter: '*@fatal' })
     expect(l.settings.filter.patterns[0].level.value).toBe('fatal')
     l.settings({ filter: 'foo' })
     expect(l.settings.filter.patterns[0].level.value).toBe('debug')
@@ -232,7 +235,7 @@ describe('filter', () => {
   it('LOG_FILTER envar config when invalid triggers readable log warning', () => {
     const calls = mockConsoleLog()
     process.env.LOG_FILTER = '**'
-    Logger.create()
+    RootLogger.create()
     expect(calls).toMatchSnapshot()
     unmockConsoleLog()
   })
@@ -243,7 +246,7 @@ describe('level', () => {
     it('considers instance time config first', () => {
       process.env.NODE_ENV = 'production'
       process.env.LOG_LEVEL = 'fatal'
-      const l = Logger.create({ filter: { level: 'fatal' } })
+      const l = RootLogger.create({ filter: { level: 'fatal' } })
       l.settings({ filter: { level: 'trace' } })
       expect(l.settings.filter.patterns[0].level.value).toEqual('trace')
     })
@@ -251,25 +254,25 @@ describe('level', () => {
     it('then considers construction time config', () => {
       process.env.NODE_ENV = 'production'
       process.env.LOG_LEVEL = 'fatal'
-      const l = Logger.create({ filter: { level: 'trace' } })
+      const l = RootLogger.create({ filter: { level: 'trace' } })
       expect(l.settings.filter.patterns[0].level.value).toEqual('trace')
     })
 
     it('then considers LOG_LEVEL env var', () => {
       process.env.NODE_ENV = 'production'
       process.env.LOG_LEVEL = 'trace'
-      const l = Logger.create()
+      const l = RootLogger.create()
       expect(l.settings.filter.patterns[0].level.value).toEqual('trace')
     })
 
     it('then considers NODE_ENV=production', () => {
       process.env.NODE_ENV = 'production'
-      const l = Logger.create()
+      const l = RootLogger.create()
       expect(l.settings.filter.patterns[0].level.value).toEqual('info')
     })
 
     it('then defaults to debug', () => {
-      const l = Logger.create()
+      const l = RootLogger.create()
       expect(l.settings.filter.patterns[0].level.value).toEqual('debug')
     })
   })
@@ -282,13 +285,13 @@ describe('level', () => {
   it('LOG_LEVEL env var config is treated case insensitive', () => {
     process.env.NODE_ENV = 'production'
     process.env.LOG_LEVEL = 'TRACE'
-    const l = Logger.create()
+    const l = RootLogger.create()
     expect(l.settings.filter.patterns[0].level.value).toEqual('trace')
   })
 
   it('LOG_LEVEL env var config when invalid triggers thrown readable error', () => {
     process.env.LOG_LEVEL = 'ttrace'
-    expect(() => Logger.create()).toThrowErrorMatchingInlineSnapshot(
+    expect(() => RootLogger.create()).toThrowErrorMatchingInlineSnapshot(
       `"Could not parse environment variable LOG_LEVEL into LogLevel. The environment variable was: ttrace. A valid environment variable must be like: fatal, error, warn, info, debug, trace"`
     )
   })
@@ -296,7 +299,7 @@ describe('level', () => {
 
 describe('data', () => {
   it('all defaults to false if process.NODE_ENV is not production', () => {
-    expect(Logger.create().settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -304,7 +307,7 @@ describe('data', () => {
       }
     `)
     process.env.NODE_ENV = 'not production'
-    expect(Logger.create().settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -313,7 +316,7 @@ describe('data', () => {
     `)
 
     process.env.NODE_ENV = 'production'
-    expect(Logger.create().settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": true,
         "pid": true,
@@ -323,7 +326,7 @@ describe('data', () => {
   })
 
   it('merges initial setting with defaults', () => {
-    expect(Logger.create({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -331,7 +334,7 @@ describe('data', () => {
       }
     `)
     process.env.NODE_ENV = 'not production'
-    expect(Logger.create({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -339,7 +342,7 @@ describe('data', () => {
       }
     `)
     process.env.NODE_ENV = 'production'
-    expect(Logger.create({ data: { time: false } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create({ data: { time: false } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": true,
         "pid": true,
@@ -349,7 +352,7 @@ describe('data', () => {
   })
 
   it('merges incremental changes with previous state', () => {
-    expect(Logger.create().settings({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -357,7 +360,7 @@ describe('data', () => {
       }
     `)
     process.env.NODE_ENV = 'not production'
-    expect(Logger.create().settings({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings({ data: { time: true } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": false,
         "pid": false,
@@ -365,7 +368,7 @@ describe('data', () => {
       }
     `)
     process.env.NODE_ENV = 'production'
-    expect(Logger.create().settings({ data: { time: false } }).settings.data).toMatchInlineSnapshot(`
+    expect(RootLogger.create().settings({ data: { time: false } }).settings.data).toMatchInlineSnapshot(`
       Object {
         "hostname": true,
         "pid": true,


### PR DESCRIPTION
closes graphql-nexus/nexus#892

This turns Nexus Logger into a singleton system.

This means the constructor is removed from the API and in its place is a
pre-constructed logger. This is the root logger. All consumers of this
library should use it or create sub-loggers. This approach is like
Python's standard library logger. It makes it possible for application
level developers to centrally turn on, off, etc. loggers.

Filter syntax has been enhanced so that all paths have an implied root which can be specified explicitly as `.`: So these these two patterns are the same thing:

```
.:app:router = app:router
.:*          = *
```

You shouldn't normally need to use the root explicitly, but it does enable a few exclusive ways to interact with the root logger, for example:

```
.        only show logs from root logger
.@info   only show logs from root logger at info level
```

BREAKING CHANGE:

1. Constructor Access

	Before:
	
	```ts
	import * as Logger from '@nexus/logger'
	
	const log = Logger.create({ name: 'foobar' })
	```
	
	Now:
	
	```ts
	import * as Logger from '@nexus/logger'
	
	const log = Logger.log.child('foobar')
	```

	Consumers can use the singleton logger directly, like so:
	
	```ts
	import { log } from '@nexus/logger'
	
	log.info('foobar')
	```
	
	However libraries should use clearly named child-loggers so that applications can easily filter them in or out and to simply improve readability of logs (seeing that they come from your library).

2. Distinction between negation and removal filtering

	Possibly working like this before but now formalized, tested, and documented rather than incidental.

	Negation and removal share the same syntax but have different positions.

	A negation filter is simply the act of reversing the match:

	```
	!app
	```
	
	This will match any log at any level except at app path at default level.

	The surprising part here might be how logs at all levels get included. If your goal is to just remove app logs, then you can use a removal filter like this:

	```
	*,!app
	```
	
	This will match any log at _default level_ except for those at app path.

	In the future we may create separate syntaxes for both, e.g. `!!` vs `!` rather than relying on position. We'll see how this goes.