### PR TITLE
feat(data): lazy context prop

### DIFF
--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -210,6 +210,5 @@ function rec(data?: Partial<Pick<LogRecord, 'level' | 'path'>>): LogRecord {
     ...data,
     // not overridable
     event: 'foo',
-    context: {},
   }
 }

--- a/src/prettifier.spec.ts
+++ b/src/prettifier.spec.ts
@@ -6,11 +6,8 @@ import { spanChar } from './utils'
 
 function makeRec(data?: Omit<Partial<LogRecord>, 'event'>): LogRecord {
   return {
-    hostname: 'host',
-    pid: 0,
-    time: 0,
     level: 1,
-    path: ['root'],
+    path: ['foob'],
     ...data,
     event: 'foo', // do not allow changing b/c headers width below depends on this value
   }
@@ -46,7 +43,7 @@ describe('singleline', () => {
     })
     const l = render()
     expect(l).toMatchInlineSnapshot(
-      `"— root foo  --  key: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"`
+      `"— foob foo  --  key: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"`
     )
     expect(trimTrailingNewline(l).length).toBeLessThanOrEqual(terminalWidth)
   })
@@ -57,7 +54,7 @@ describe('singleline', () => {
     })
     const l = render()
     expect(l).toMatchInlineSnapshot(
-      `"— root foo  --  ke1: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'  ke2: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"`
+      `"— foob foo  --  ke1: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'  ke2: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"`
     )
     expect(trimTrailingNewline(l).length).toBeLessThanOrEqual(terminalWidth)
   })
@@ -72,7 +69,7 @@ describe('multiline', () => {
   it('used if context does not fit singleline', () => {
     rec.context = createContext({ key: { size: terminalContextWidth + 1 /* force multi */ } })
     expect(render()).toMatchInlineSnapshot(`
-      "— root foo
+      "— foob foo
         | key  'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
     `)
   })
@@ -88,7 +85,7 @@ describe('multiline', () => {
       },
     })
     expect(render()).toMatchInlineSnapshot(`
-      "— root foo
+      "— foob foo
         | ke1  'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         | ke2  'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
     `)

--- a/src/prettifier.spec.ts
+++ b/src/prettifier.spec.ts
@@ -11,7 +11,6 @@ function makeRec(data?: Omit<Partial<LogRecord>, 'event'>): LogRecord {
     time: 0,
     level: 1,
     path: ['root'],
-    context: {},
     ...data,
     event: 'foo', // do not allow changing b/c headers width below depends on this value
   }

--- a/src/prettifier.ts
+++ b/src/prettifier.ts
@@ -188,7 +188,7 @@ export function render(opts: Options, logRecord: Logger.LogRecord): string {
     terminalWidth - gutterWidth - preContextWidth - separators.context.singleLine.symbol.length
   let contextColumnsConsumed = 0
 
-  const contextEntries = Object.entries(logRecord.context)
+  const contextEntries = logRecord.context ? Object.entries(logRecord.context) : []
   let widestKey = 0
   let first = true
 

--- a/src/root-logger.ts
+++ b/src/root-logger.ts
@@ -27,7 +27,7 @@ export function create(opts?: Options): RootLogger {
     return logger
   }) as SettingsManager
   Object.assign(settingsManager, settings)
-  const loggerLink = Logger.create({ settings: settingsManager }, null, {})
+  const loggerLink = Logger.create({ settings: settingsManager }, null, undefined)
   const logger = loggerLink.logger as RootLogger
   logger.settings = settingsManager
   return logger

--- a/tests/__helpers.ts
+++ b/tests/__helpers.ts
@@ -30,8 +30,6 @@ export function createMockOutput(): MockOutput {
       let log: any
       try {
         log = JSON.parse(message)
-        log.time = 0
-        log.pid = 0
         output.memory.json.push(log)
       } catch (e) {
         if (e instanceof SyntaxError) {

--- a/tests/__snapshots__/rest.spec.ts.snap
+++ b/tests/__snapshots__/rest.spec.ts.snap
@@ -10,14 +10,10 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "bye",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -27,38 +23,26 @@ Array [
   Object {
     "event": "hi",
     "level": 6,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "hi",
     "level": 5,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "hi",
     "level": 4,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "hi",
     "level": 2,
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "event": "hi",
     "level": 1,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -74,8 +58,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -91,8 +73,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -107,8 +87,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -123,8 +101,6 @@ Array [
     },
     "event": "hi",
     "level": 3,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -137,8 +113,6 @@ Array [
     "path": Array [
       "tim",
     ],
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -151,8 +125,6 @@ Array [
     "path": Array [
       "tim",
     ],
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -169,8 +141,6 @@ Array [
     "path": Array [
       "b1",
     ],
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "context": Object {
@@ -182,8 +152,6 @@ Array [
     "path": Array [
       "b2",
     ],
-    "pid": 0,
-    "time": 0,
   },
   Object {
     "context": Object {
@@ -195,8 +163,6 @@ Array [
     "path": Array [
       "b3",
     ],
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -209,8 +175,6 @@ Array [
     "path": Array [
       "b",
     ],
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;
@@ -220,8 +184,6 @@ Array [
   Object {
     "event": "foo",
     "level": 6,
-    "pid": 0,
-    "time": 0,
   },
 ]
 `;

--- a/tests/__snapshots__/rest.spec.ts.snap
+++ b/tests/__snapshots__/rest.spec.ts.snap
@@ -14,7 +14,6 @@ Array [
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "bye",
     "level": 3,
     "pid": 0,
@@ -26,42 +25,36 @@ Array [
 exports[`.<level> log methods one for each log level 1`] = `
 Array [
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 6,
     "pid": 0,
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 5,
     "pid": 0,
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 4,
     "pid": 0,
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 3,
     "pid": 0,
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 2,
     "pid": 0,
     "time": 0,
   },
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 1,
     "pid": 0,
@@ -139,7 +132,6 @@ Array [
 exports[`.child creates a sub logger 1`] = `
 Array [
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 3,
     "path": Array [
@@ -154,7 +146,6 @@ Array [
 exports[`.child inherits level from parent 1`] = `
 Array [
   Object {
-    "context": Object {},
     "event": "hi",
     "level": 1,
     "path": Array [
@@ -213,7 +204,6 @@ Array [
 exports[`.child reacts to level changes in root logger 1`] = `
 Array [
   Object {
-    "context": Object {},
     "event": "foo",
     "level": 1,
     "path": Array [
@@ -228,7 +218,6 @@ Array [
 exports[`output defaults to stdout for all levels 1`] = `
 Array [
   Object {
-    "context": Object {},
     "event": "foo",
     "level": 6,
     "pid": 0,

--- a/tests/rest.spec.ts
+++ b/tests/rest.spec.ts
@@ -153,9 +153,13 @@ describe('.child', () => {
   })
 
   it('is unable to change context of parent', () => {
-    log.child('b').addToContext({ foo: 'bar' })
-    log.info('qux')
-    expect(output.memory.json[0].context).toEqual({})
+    log.child('b').addToContext({ foo1: 'bar' })
+    log.info('qux1')
+    expect(output.memory.json[0].context).toEqual(undefined)
+    log.addToContext({ toto: 'one' })
+    log.child('b').addToContext({ foo2: 'bar' })
+    log.info('qux2')
+    expect(output.memory.json[1].context).toEqual({ toto: 'one' })
   })
 
   it('is unable to change context of siblings', () => {
@@ -187,7 +191,7 @@ describe('filtering', () => {
     foobar.info('berp') // should be filtered out
     expect(output.memory.raw).toMatchInlineSnapshot(`
       Array [
-        "{\\"context\\":{},\\"event\\":\\"boop\\",\\"level\\":3,\\"path\\":[\\"foo\\",\\"bar\\"]}
+        "{\\"event\\":\\"boop\\",\\"level\\":3,\\"path\\":[\\"foo\\",\\"bar\\"]}
       ",
       ]
     `)


### PR DESCRIPTION
This makes working with JSON logs more reasonable in a terminal. This
may cause problems in systems with poor support for nullability. In the
future we may bring back an option to have a strict context property.
Its default would probably be off in dev and on in prod.

BREAKING CHANGE:

1. When context is empty then the `context` property in the respective log record will be omitted.

      Before:

      ```
      log.info('hello')
      // { "context": {}, ... }
      ```

      Now:

      ```
      log.info('hello')
      // { ... }
      ```