### PR TITLE
feat: configurable log handler hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { demo } from './demo'
-export { Logger } from './logger'
+export { Logger, LogRecord } from './logger'
 export { RootLogger } from './root-logger'
 export { Data as SettingsData, Input as SettingsInput } from './settings'
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,7 +18,7 @@ export type LogRecord = {
   hostname?: string
 }
 
-export type LogHandler = (logRecord: LogRecord) => void;
+export type LogHandler = (logRecord: LogRecord) => void
 
 type Log = (event: string, context?: Context) => void
 
@@ -55,10 +55,7 @@ export function create(
     })
   }
 
-  function send(levelLabel: Name,
-                event: string,
-                localContext: undefined | Context,
-                handler?: LogHandler) {
+  function send(levelLabel: Name, event: string, localContext: undefined | Context, handler?: LogHandler) {
     const level = LEVELS[levelLabel].number
     const logRec: LogRecord = {
       event,
@@ -92,7 +89,7 @@ export function create(
       rootState.settings.output.write(logMsg + OS.EOL)
 
       if (rootState.settings?.handler) {
-        rootState.settings.handler(logRec);
+        rootState.settings.handler(logRec)
       }
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,6 +18,8 @@ export type LogRecord = {
   hostname?: string
 }
 
+export type LogHandler = (logRecord: LogRecord) => void;
+
 type Log = (event: string, context?: Context) => void
 
 export type Logger = {
@@ -53,7 +55,10 @@ export function create(
     })
   }
 
-  function send(levelLabel: Name, event: string, localContext: undefined | Context) {
+  function send(levelLabel: Name,
+                event: string,
+                localContext: undefined | Context,
+                handler?: LogHandler) {
     const level = LEVELS[levelLabel].number
     const logRec: LogRecord = {
       event,
@@ -85,6 +90,10 @@ export function create(
         ? Prettifier.render(rootState.settings.pretty, logRec)
         : JSON.stringify(logRec)
       rootState.settings.output.write(logMsg + OS.EOL)
+
+      if (rootState.settings?.handler) {
+        rootState.settings.handler(logRec);
+      }
     }
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import * as Filter from './filter'
 import * as Level from './level'
 import * as Output from './output'
 import { casesHandled, isEmpty, omitUndefinedKeys, parseFromEnvironment } from './utils'
+import { LogHandler } from "./logger";
 
 export type Manager = Data & {
   (newSettings: Input): void
@@ -29,10 +30,12 @@ export type Data = Readonly<{
     pid: boolean
     hostname: boolean
   }
-  output: Output.Output
+  output: Output.Output,
+  handler: LogHandler | false
 }>
 
 export type Input = {
+  handler?: LogHandler | false,
   output?: Output.Output
   /**
    * Filter logs by path and/or level.
@@ -313,12 +316,18 @@ export function create(opts?: Input) {
     filter: isEmpty(opts?.filter) ? defaultFilterSetting() : processSettingInputFilter(opts!.filter!, null),
     output: opts?.output ?? process.stdout,
     data: processSettingInputData(opts?.data ?? {}, null),
+    handler: opts?.handler ?? false
   }
 
   const settings = ((newSettings: Input) => {
     if (newSettings.output) {
       // @ts-ignore
       settings.output = newSettings.output
+    }
+
+    if (typeof newSettings.handler === 'boolean' || newSettings.handler) {
+      // @ts-ignore
+      settings.handler = newSettings.handler
     }
 
     if ('pretty' in newSettings) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import * as Filter from './filter'
 import * as Level from './level'
 import * as Output from './output'
 import { casesHandled, isEmpty, omitUndefinedKeys, parseFromEnvironment } from './utils'
-import { LogHandler } from "./logger";
+import { LogHandler } from './logger'
 
 export type Manager = Data & {
   (newSettings: Input): void
@@ -30,12 +30,12 @@ export type Data = Readonly<{
     pid: boolean
     hostname: boolean
   }
-  output: Output.Output,
+  output: Output.Output
   handler: LogHandler | false
 }>
 
 export type Input = {
-  handler?: LogHandler | false,
+  handler?: LogHandler | false
   output?: Output.Output
   /**
    * Filter logs by path and/or level.
@@ -316,7 +316,7 @@ export function create(opts?: Input) {
     filter: isEmpty(opts?.filter) ? defaultFilterSetting() : processSettingInputFilter(opts!.filter!, null),
     output: opts?.output ?? process.stdout,
     data: processSettingInputData(opts?.data ?? {}, null),
-    handler: opts?.handler ?? false
+    handler: opts?.handler ?? false,
   }
 
   const settings = ((newSettings: Input) => {

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -7,7 +7,7 @@ import {
   resetBeforeEachTest,
   unmockConsoleLog,
 } from './__helpers'
-import { LogRecord } from "../src/logger";
+import { LogRecord } from '../src/logger'
 
 let log: Logger.RootLogger
 let output: MockOutput
@@ -375,49 +375,52 @@ describe('data', () => {
         "pid": true,
         "time": false,
       }
-    `);
-  });
-});
+    `)
+  })
+})
 
-describe("handler", () => {
-  describe(".disabled", () => {
-    it("default disabled", () => {
-      expect(RootLogger.create().settings.handler).toBeFalsy();
-    });
-    it("disable with settings", () => {
-      const l = RootLogger.create({ handler: () => {} });
-      l.settings({ handler: false });
-      expect(l.settings.handler).toBeFalsy();
-    });
-  });
+describe('handler', () => {
+  function handler() {
+    return jest.fn((logRecord: LogRecord): void => {
+      logRecord.level
+    })
+  }
 
-  describe("set", () => {
-    describe("create with handler", () => {
-      let result!: LogRecord;
-      const handler = (r: LogRecord) => {
-        result = r;
-      };
-      const l = RootLogger.create({ handler });
-      l.error("a", {});
-      expect(l.settings.handler).toBeTruthy();
-      expect(result.level).toEqual(5);
-    });
+  describe('.disabled', () => {
+    it('default disabled', () => {
+      expect(RootLogger.create().settings.handler).toBeFalsy()
+    })
 
-    describe("set with settings", () => {
-      let result!: LogRecord;
-      const l = RootLogger.create();
-      l.settings({ handler: (logRecord => result = logRecord) });
-      l.fatal("a");
-      expect(result).toBeDefined();
-      expect(result.level).toEqual(6);
-    });
+    it('disable with settings', () => {
+      const l = RootLogger.create({ output, handler: () => {} })
+      l.settings({ handler: false })
+      expect(l.settings.handler).toBeFalsy()
+    })
+  })
 
-    describe("persist to children", () => {
-      let result!: LogRecord;
-      const l = RootLogger.create({ handler: (logRecord => result = logRecord) }).child("child");
-      l.fatal("a");
-      expect(result).toBeDefined();
-      expect(result.level).toEqual(6);
-    });
-  });
-});
+  describe('set', () => {
+    describe('create with handler', () => {
+      const l = RootLogger.create({ output, handler: handler() })
+      expect(l.settings.handler).toBeTruthy()
+      expect(l.settings.handler).toHaveBeenCalledTimes(0)
+    })
+
+    describe('set with settings', () => {
+      let result!: LogRecord
+      const l = RootLogger.create({})
+      l.settings({ handler: handler() })
+      expect(l.settings.handler).toBeDefined()
+      expect(l.settings.handler).toHaveBeenCalledTimes(0)
+    })
+
+    describe('handler is called', () => {
+      const a = (logRecord: LogRecord): void => {
+        logRecord.level
+      }
+      const h = jest.fn(a)
+      const l = RootLogger.create({ handler: h }).child('baby').child('infant')
+      l.info('a')
+      expect(h).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -374,6 +374,49 @@ describe('data', () => {
         "pid": true,
         "time": false,
       }
-    `)
-  })
-})
+    `);
+  });
+});
+
+describe("handler", () => {
+  describe(".disabled", () => {
+    it("default disabled", () => {
+      expect(RootLogger.create().settings.handler).toBeFalsy();
+    });
+    it("disable with settings", () => {
+      const l = RootLogger.create({ handler: () => {} });
+      l.settings({ handler: false });
+      expect(l.settings.handler).toBeFalsy();
+    });
+  });
+
+  describe("set", () => {
+    describe("create with handler", () => {
+      let result!: LogRecord;
+      const handler = (r: LogRecord) => {
+        result = r;
+      };
+      const l = RootLogger.create({ handler });
+      l.error("a", {});
+      expect(l.settings.handler).toBeTruthy();
+      expect(result.level).toEqual(5);
+    });
+
+    describe("set with settings", () => {
+      let result!: LogRecord;
+      const l = RootLogger.create();
+      l.settings({ handler: (logRecord => result = logRecord) });
+      l.fatal("a");
+      expect(result).toBeDefined();
+      expect(result.level).toEqual(6);
+    });
+
+    describe("persist to children", () => {
+      let result!: LogRecord;
+      const l = RootLogger.create({ handler: (logRecord => result = logRecord) }).child("child");
+      l.fatal("a");
+      expect(result).toBeDefined();
+      expect(result.level).toEqual(6);
+    });
+  });
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -7,6 +7,7 @@ import {
   resetBeforeEachTest,
   unmockConsoleLog,
 } from './__helpers'
+import { LogRecord } from "../src/logger";
 
 let log: Logger.RootLogger
 let output: MockOutput


### PR DESCRIPTION
Configurable via the logger's settings and inheritable by children. Function receives the native output object after before being printed.  Defaults to false.

closes graphql-nexus/nexus#945.

#### TODO

- [ ] docs
- [x] tests
